### PR TITLE
Update Internal Models and Code to Reflect latest API spec changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "karma-jasmine-html-reporter": "~1.7.0",
         "postcss": "^8.3.11",
         "tailwindcss": "^2.2.19",
+        "ts-essentials": "^9.0.0",
         "typescript": "~4.3.5"
       }
     },
@@ -3002,6 +3003,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15208,6 +15221,15 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.0.0.tgz",
+      "integrity": "sha512-pow5YBSknf/PyoDhr8vsb93+hZah/jSzhdHA3GMjSzUuZIDZH+rV7tvN5DCbN4hi7QJXdteDv8D9HdDCSwXBUw==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -15230,18 +15252,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -18936,6 +18946,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
       }
     },
     "ansi-html": {
@@ -28284,6 +28302,13 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "ts-essentials": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.0.0.tgz",
+      "integrity": "sha512-pow5YBSknf/PyoDhr8vsb93+hZah/jSzhdHA3GMjSzUuZIDZH+rV7tvN5DCbN4hi7QJXdteDv8D9HdDCSwXBUw==",
+      "dev": true,
+      "requires": {}
+    },
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -28302,12 +28327,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
-    },
-    "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
     "type-is": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "karma-jasmine-html-reporter": "~1.7.0",
     "postcss": "^8.3.11",
     "tailwindcss": "^2.2.19",
+    "ts-essentials": "^9.0.0",
     "typescript": "~4.3.5"
   },
   "volta": {

--- a/src/app/shared/models/iteration.model.ts
+++ b/src/app/shared/models/iteration.model.ts
@@ -2,13 +2,13 @@ import {Proposal} from "./proposal.model";
 import {CommentsSummary} from "./commentsSummary.model";
 
 export interface Iteration{
-  id: string;
-  position: number;
-  open: boolean;
+  readonly id: string;
+  readonly position: number;
+  readonly open: boolean;
   goal: string;
   description: string;
   files: Array<string>;
-  comments: CommentsSummary;
+  readonly comments: CommentsSummary;
   deadline: string;
-  timeline: Array<Proposal>;
+  readonly timeline: Array<Proposal>;
 }

--- a/src/app/shared/models/organization.model.ts
+++ b/src/app/shared/models/organization.model.ts
@@ -1,7 +1,5 @@
 export interface Organization {
-  id: string;
+  readonly id: string;
   name: string;
-  users: Array<string>;
-  projects: Array<string>;
   logo: string | null;
 }

--- a/src/app/shared/models/proposal.model.ts
+++ b/src/app/shared/models/proposal.model.ts
@@ -2,11 +2,11 @@ import {CommentsSummary} from "./commentsSummary.model";
 import {Rating} from "./rating.model";
 
 export interface Proposal{
-  id: string;
+  readonly id: string;
   description: string;
-  author: string;
-  creationDate: string;
+  readonly author: string;
+  readonly creationDate: string;
   files: Array<string>;
-  comments: CommentsSummary;
-  rating: Rating;
+  readonly comments: CommentsSummary;
+  readonly rating: Rating;
 }

--- a/src/app/shared/models/topic.model.ts
+++ b/src/app/shared/models/topic.model.ts
@@ -1,16 +1,16 @@
 export interface TopicSummary {
-  id: string;
-  type: string;
+  readonly id: string;
+  readonly type: string;
   title: string;
-  author: string;
-  highlightedProposal: string;
-  activeUsers: Array<String>;
-  currentIteration: string;
+  readonly author: string;
+  readonly highlightedProposal: string;
+  readonly activeUsers: Array<String>;
+  readonly currentIteration: string;
 }
 
 export interface Topic extends TopicSummary{
-  iterations?: Array<String>;
-  creationDate?: string;
+  readonly iterations?: Array<String>;
+  readonly creationDate?: string;
 }
 
 export class TopicClass implements Topic{

--- a/src/app/shared/models/user.model.ts
+++ b/src/app/shared/models/user.model.ts
@@ -1,7 +1,7 @@
 export interface User {
-  id?: string;
+  readonly id?: string;
   firstName: string;
   lastName: string;
-  email: string;
+  readonly email: string;
   profilePic?: string;
 }

--- a/src/app/shared/services/organization.service.ts
+++ b/src/app/shared/services/organization.service.ts
@@ -1,22 +1,24 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
 import {User} from "../models/user.model";
 import {environment} from "../../../environments/environment";
 import {Organization} from "../models/organization.model";
-import {Project} from "../models/project.model";
+import {ProjectSummary} from "../models/project.model";
+import {OmitReadonly} from "../../../utility-types";
 
 @Injectable({
   providedIn: 'root'
 })
 export class OrganizationService {
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {
+  }
 
   getUsers(orgId: string) {
     return this.http.get<Array<User>>(`${environment.apiUrl}/Org/${orgId}/users`);
   }
 
-  createOrganization(org: Organization) {
+  createOrganization(org: OmitReadonly<Organization>) {
     return this.http.post<Organization>(`${environment.apiUrl}/Org`, org);
   }
 
@@ -24,8 +26,8 @@ export class OrganizationService {
     return this.http.get<Organization>(`${environment.apiUrl}/Org/${orgId}`);
   }
 
-  updateOrganization(org: Organization){
-    return this.http.put<Organization>(`${environment.apiUrl}/Org/${org.id}`, org);
+  updateOrganization(orgId: string, org: OmitReadonly<Organization>) {
+    return this.http.put<Organization>(`${environment.apiUrl}/Org/${orgId}`, org);
   }
 
   deleteOrganization(orgId: string) {
@@ -36,19 +38,19 @@ export class OrganizationService {
     return this.http.get<User>(`${environment.apiUrl}/Org/${orgId}/user/${userId}`);
   }
 
-  addUser(orgId: string, user: User) {
-    return this.http.post<any>(`${environment.apiUrl}/Org/${orgId}/user/${user.id}`, user);
+  addUser(orgId: string, userId: string) {
+    return this.http.post<null>(`${environment.apiUrl}/Org/${orgId}/user/${userId}`, null);
   }
 
   removeUser(orgId: string, userId: string) {
     return this.http.delete(`${environment.apiUrl}/Org/${orgId}/user/${userId}`);
   }
 
-  addProject(orgId: string, project: Project){
+  addProject(orgId: string, project: OmitReadonly<ProjectSummary>) {
     return this.http.post(`${environment.apiUrl}/Org/${orgId}/project`, project);
   }
 
-  getProjects(orgId: string){
+  getProjects(orgId: string) {
     return this.http.get<Array<string>>(`${environment.apiUrl}/Org/${orgId}/projects`);
   }
 }

--- a/src/app/shared/services/project.service.ts
+++ b/src/app/shared/services/project.service.ts
@@ -3,6 +3,7 @@ import {HttpClient} from "@angular/common/http";
 import {ProjectSummary} from "../models/project.model";
 import {environment} from "../../../environments/environment";
 import {Topic, TopicSummary} from "../models/topic.model";
+import { OmitReadonly } from "src/utility-types";
 
 @Injectable({
     providedIn: 'root'
@@ -21,7 +22,7 @@ export class ProjectService {
     return this.httpClient.get<Array<TopicSummary>>(`${environment.apiUrl}/Project/${projectId}/topics`);
   }
 
-  addTopic(projectId: string, topic: Topic) {
+  addTopic(projectId: string, topic: OmitReadonly<Topic>) {
     return this.httpClient.post<Topic>(`${environment.apiUrl}/Project/${projectId}/topic`, topic);
   }
 }

--- a/src/app/shared/services/topic.service.ts
+++ b/src/app/shared/services/topic.service.ts
@@ -3,6 +3,7 @@ import {HttpClient} from "@angular/common/http";
 import {Topic} from "../models/topic.model";
 import {environment} from "../../../environments/environment";
 import {Iteration} from "../models/iteration.model";
+import { OmitReadonly } from 'src/utility-types';
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +21,7 @@ export class TopicService {
     return this.http.get<Array<Iteration>>(`${environment.apiUrl}/Topic/${topicId}/iterations`);
   }
 
-  addTopicIteration(topicId: string, iteration: Iteration) {
+  addTopicIteration(topicId: string, iteration: OmitReadonly<Iteration>) {
     return this.http.post(`${environment.apiUrl}/Topic/${topicId}/iterations`, {iteration});
   }
 }

--- a/src/app/shared/services/user.service.ts
+++ b/src/app/shared/services/user.service.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from "@angular/common/http";
 import {User} from "../models/user.model";
 import {environment} from "../../../environments/environment";
+import {OmitReadonly} from "../../../utility-types";
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +16,7 @@ export class UserService {
     return this.http.get<User>(`${environment.apiUrl}/User/${userId}`);
   }
 
-  updateUser(user: User) {
-    return this.http.put<any>(`${environment.apiUrl}/User/${user.id}`, user);
+  updateUser(userId: string, user: OmitReadonly<User>) {
+    return this.http.put<User>(`${environment.apiUrl}/User/${userId}`, user);
   }
 }

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,0 +1,3 @@
+import {ReadonlyKeys} from "ts-essentials";
+
+export type OmitReadonly<T extends object> = Omit<T, ReadonlyKeys<T>>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "target": "es2017",
     "module": "es2020",
     "lib": [
-      "es2018",
+      "es2020",
       "dom"
     ]
   },


### PR DESCRIPTION
- updated all the models where fields are readonly in api spec, they also are in the code
- organization had two fields removed because in the spec we have separate endpoints to secure the transmission of such data
- service code that has path params now they are required explicitly as a function parameter
- service code that requires types of objects to perform updates now doesn't need the read-only fields, the same as it is done in the spec
- added with ts-essentials omit readonly, does magic that filters out readonly fields